### PR TITLE
Remove name of venue while contract is not signed.

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ We're hoping that wonderful people will join us to share their enthusiasm with u
 ## The plan
 
 EnthusiastiCon will be held on **March 31 and April 1, 2018** in Berlin.
-Saturday will be a day full of talks at the [Wikimedia Deutschland](https://www.openstreetmap.org/node/2551527703) space.
+Saturday will be a day full of talks.
 For Sunday we're discussing an open space for sharing and collaboration.
 
 ## Who Can Attend


### PR DESCRIPTION
I was told that while we don't have a signed contract, it's not good form to announce the space. While I hope and believe this is only a formality, can we withhold the announcement for a few days? 