### PR TITLE
CFP: extend deadline

### DIFF
--- a/_pages/cfp.md
+++ b/_pages/cfp.md
@@ -39,7 +39,7 @@ This is why we're asking for a proposed timeline.
 
 CfP opening on February 2, 2018
 
-CfP closing on ~~[February 28, 2018](https://www.timeanddate.com/countdown/generic?iso=20180305T235959&p0=37&msg=EnthusiastiCon+CfP+Deadline)~~ The CFP was extended to March 5, 2018!
+CfP closing on ~~February 28, 2018~~ The CFP was extended to [March 5, 2018](https://www.timeanddate.com/countdown/generic?iso=20180305T235959&p0=37&msg=EnthusiastiCon+CfP+Deadline)!
 
 Selection notification will be sent March 12, 2018
 

--- a/_pages/cfp.md
+++ b/_pages/cfp.md
@@ -39,7 +39,7 @@ This is why we're asking for a proposed timeline.
 
 CfP opening on February 2, 2018
 
-CfP closing on ~~[February 28, 2018](https://www.timeanddate.com/countdown/generic?iso=20180228T235959&p0=37&msg=EnthusiastiCon+CfP+Deadline)~~ The CFP was extended to March 5, 2018!
+CfP closing on ~~[February 28, 2018](https://www.timeanddate.com/countdown/generic?iso=20180305T235959&p0=37&msg=EnthusiastiCon+CfP+Deadline)~~ The CFP was extended to March 5, 2018!
 
 Selection notification will be sent March 12, 2018
 

--- a/_pages/cfp.md
+++ b/_pages/cfp.md
@@ -39,7 +39,7 @@ This is why we're asking for a proposed timeline.
 
 CfP opening on February 2, 2018
 
-CfP closing on [February 28, 2018](https://www.timeanddate.com/countdown/generic?iso=20180228T235959&p0=37&msg=EnthusiastiCon+CfP+Deadline)
+CfP closing on ~~[February 28, 2018](https://www.timeanddate.com/countdown/generic?iso=20180228T235959&p0=37&msg=EnthusiastiCon+CfP+Deadline)~~ The CFP was extended to March 5, 2018!
 
 Selection notification will be sent March 12, 2018
 

--- a/index.md
+++ b/index.md
@@ -21,6 +21,8 @@ This conference is open to everyone!
 We would be delighted to receive a [talk proposal]({{ site.baseurl }}/cfp) from you.
 We have room for up to 100 people at the venue and attendance will be free, though we may charge a no-show fee.
 
+We extended the Call for Proposals. You can still hand in your talk idea by Monday!
+
 ## Our Sponsors
 
 {::nomarkdown}


### PR DESCRIPTION
This PR changes the CFP page to tell people we extended the deadline. We also need to send out a newsletter, I guess.

Should we also advertise it on the landing page?

Cheers