### PR TITLE
Add underlines back to links

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -5,10 +5,7 @@ subtitle: About EnthusiastiCon
 permalink: /about/
 ---
 
-<div class="pretty-links">
-
 More information about EnthusiastiCon 2020 coming soon!
 
 You can find the site for the 2019 edition [here](/2019), and videos of the 2018 talks [here](https://www.youtube.com/channel/UCysZMezyfn6QuDPNlbl6jHQ/videos)!
 
-</div>

--- a/_pages/coc.md
+++ b/_pages/coc.md
@@ -4,8 +4,6 @@ title: Code of Conduct
 permalink: /coc/
 ---
 
-<div class="pretty-links">
-
 # Code of Conduct
 
 We value the participation of each member of the community and want all attendees feel safe and welcome.
@@ -48,4 +46,3 @@ License
 
 This Code of Conduct was mostly copied from the [!!Con Code of Conduct](http://bangbangcon.com/conduct.html) which is under a [Creative Commons Zero](http://creativecommons.org/about/cc0) license. It was forked from the [PyCon 2013 Code of Conduct](https://us.pycon.org/2013/about/code-of-conduct/), which is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/), and which itself was forked from [an example policy from the Geek Feminism wiki, created by the Ada Initiative and other volunteers](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) and available under a [Creative Commons Zero](http://creativecommons.org/about/cc0) license.
 
-</div>

--- a/_pages/programme.md
+++ b/_pages/programme.md
@@ -4,8 +4,6 @@ title: Programme
 subtitle: Programme
 permalink: /programme/
 ---
-<div class="pretty-links">
 
 Coming soon!
 
-</div>

--- a/_pages/speakers.md
+++ b/_pages/speakers.md
@@ -4,8 +4,6 @@ title: Our speakers
 subtitle: Speakers
 permalink: /speakers/
 ---
-<div class="pretty-links">
 
 Coming soon!
 
-</div>

--- a/_pages/talks.md
+++ b/_pages/talks.md
@@ -4,8 +4,5 @@ title: Talks
 subtitle: Talks
 permalink: /talks/
 ---
-<div class="pretty-links">
 
 Coming soon!
-
-</div>

--- a/_pages/venue.md
+++ b/_pages/venue.md
@@ -4,8 +4,5 @@ title: Venue
 subtitle: Venue
 permalink: /venue/
 ---
-<div class="pretty-links">
 
 Coming soon!
-
-</div>

--- a/_sass/_site.scss
+++ b/_sass/_site.scss
@@ -48,9 +48,9 @@
   transition: background 0.1s ease-out;
   white-space: nowrap;
   color: $theme-color-light;
+  text-decoration: none;
 
   &:hover {
-    text-decoration: none;
     color: $theme-color-light;
     background-color: $theme-color-less-dark;
   }
@@ -230,14 +230,6 @@
 }
 
 @media (min-width: 768px) { .lead { font-size: 1.2rem } }
-
-.pretty-links a  {
-  background-image: none;
-}
-
-.pretty-links a:hover {
-  color: $theme-color-dark;
-}
 
 // speakers page
 

--- a/_sass/_text.scss
+++ b/_sass/_text.scss
@@ -32,10 +32,6 @@ h6 { font-size: $fs-h6; }
   p { margin-bottom: 1.5rem; }
 }
 
-.pretty-links {
-  a { @include make-link($link-color, $link-hover-color, $body-bg); }
-}
-
 hr {
   margin: $spacer 0 $spacer1;
   border: 0;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -36,7 +36,7 @@ $theme-color-less-dark:     lighten($dark-blue, 15%);
 
 // GLOBALS - LINKS ------------------
 $link-color:                $theme-color-dark;
-$link-decoration:           none;
+$link-decoration:           underline;
 $link-hover-color:          $theme-color-less-dark;
 $link-hover-decoration:     underline;
 


### PR DESCRIPTION
The link color is so close to the text color that it is a bit difficult to notice links. To make the links more readable, we can simply add underlines back to the links.

It looks like the original version of the site also had a `.pretty-links` class, which was only used on some of the pages. This doesn't seem to really be necessary, so I simply removed it to reduce complexity.

Special care was taken to avoid underlining links in the nav bar.

Before (`this form` link is difficult to notice):
![image](https://user-images.githubusercontent.com/10483186/77251677-9cf4fb00-6c47-11ea-96ee-a58a0438a203.png)

After (`this form` link stands out a bit more):
![image](https://user-images.githubusercontent.com/10483186/77251683-a7af9000-6c47-11ea-88ad-82608669241a.png)

I've tested with Chrome and Firefox.