### PR TITLE
Create button for CfP form

### DIFF
--- a/_pages/cfp.md
+++ b/_pages/cfp.md
@@ -5,7 +5,13 @@ subtitle: Call for Proposals
 permalink: /cfp/
 ---
 
-Our call for proposals is now open!  To submit a proposal please fill out [this form](https://pretalx.enthusiasticon.de/enthusiasticon-2020/cfp).
+Our call for proposals is now open!  To submit a proposal please fill out the form:
+
+{::nomarkdown}
+<div class="center">
+<a href=https://pretalx.enthusiasticon.de/enthusiasticon-2020/cfp class="button">Submit Proposal</a>
+</div>
+{:/}
 
 **The deadline for applications is the 30th April 2020**.
 

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -206,3 +206,27 @@ p.post-desc {
   width: 200px;
   margin-left: 20px;
 }
+
+
+// Button
+.button {
+    background-color: $theme-color-light;
+    color: $theme-color-dark;
+    padding: 14px 25px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    border-radius: 10px;
+    border: 2px solid $theme-color-dark;
+
+    &:hover {
+        background-color: $theme-color-less-light;
+        color: $theme-color-dark;
+        text-decoration: none;
+    }
+}
+
+.center {
+    display: flex;
+    justify-content: center;
+}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -31,6 +31,7 @@ $body-color:                $gray-dark;
 
 // GLOBALS - Theme color ---------------
 $theme-color-light:         $light-biege;
+$theme-color-less-light:    darken($theme-color-light, 15%);
 $theme-color-dark:          $dark-blue;
 $theme-color-less-dark:     lighten($dark-blue, 15%);
 


### PR DESCRIPTION
The form for the CfP doesn't stand out from the text so much. To make sure our potential speakers find it as soon as possible, this PR creates a button for the CfP form.

Before:

![image](https://user-images.githubusercontent.com/10483186/77253117-51931a80-6c50-11ea-95ea-7ff42d9fd9bf.png)

After:

![image](https://user-images.githubusercontent.com/10483186/77253126-5b1c8280-6c50-11ea-98af-720adad8afc7.png)

The button changes to a slightly darker orange when hovering over it. I've tested on Firefox and Chrome and the mobile device emulator on Chrome.

