### PR TITLE
Add embedded schedule for 2020, and mention it on the front page

### DIFF
--- a/_pages/programme.md
+++ b/_pages/programme.md
@@ -5,4 +5,21 @@ subtitle: Programme
 permalink: /programme/
 ---
 
-We'll announce the programme soon!
+<link rel="stylesheet" type="text/css" href="https://pretalx.enthusiasticon.de/enthusiasticon-2020/schedule/widget/v1.css">
+<script type="text/javascript" src="https://pretalx.enthusiasticon.de/enthusiasticon-2020/schedule/widget/v1.en.js" async></script>
+
+The stream will start at around 10:00 UTC+2, and we'll do the opening remarks at around 10:15! After that, there are four blocks of talks, plus a keynote! Note that the talks might happen a bit earlier in a block than noted in this schedule.
+
+You can find an iCal version, a changelog, an RSS feed, as well as lists of speakers and talks on our [pretalx](https://pretalx.enthusiasticon.de/enthusiasticon-2020/schedule/){:target="_blank"}.
+
+**All times in the schedule are in UTC+2 (Berlin time)!**
+
+<pretalx-schedule-widget event="https://pretalx.enthusiasticon.de/enthusiasticon-2020/" height="1500px" style="font-size: 80%; z-index: 0;"></pretalx-schedule-widget>
+<noscript>
+   <div class="pretalx-widget">
+        <div class="pretalx-widget-info-message">
+            JavaScript is disabled in your browser. To access our schedule without JavaScript,
+            please <a target="_blank" href="https://pretalx.enthusiasticon.de/enthusiasticon-2020/schedule/">click here</a>.
+        </div>
+    </div>
+</noscript>

--- a/index.md
+++ b/index.md
@@ -9,12 +9,11 @@ We will talk about what excites us the most about programming — the strange, t
 
 We're hoping that wonderful people will join us to share their enthusiasm or listen to what makes fellow programmers beam with joy about our craft.
 
-Please note: the 2020 CfP is now closed.
-
 ## The Plan
 
 EnthusiastiCon will be held **remotely** on <b>June 6th 2020</b> for a day of 10 minute talks.
-We'll publish the schedule and details on how everything will work remotely closer to the time.
+
+Take a look at the [schedule](/programme/)! We'll publish details on how everything will work remotely closer to the time.
 
 
 ## Accessibility
@@ -65,10 +64,6 @@ Registration will be open closer to the event. Sign up to our mailing list for u
 
 &nbsp;
 &nbsp;
-
-## Who Will Speak
-
-Our [call for proposals](/cfp/) is now closed! We will announce our speakers soon.
 
 
 ## Contact Us!


### PR DESCRIPTION
This is how it looks like:

![](https://user-images.githubusercontent.com/81277/82812346-1f41ab80-9e93-11ea-8cd2-36e5bed671ca.png)
