### PR TITLE
Add logistics 2020 page

### DIFF
--- a/_pages/logistics.md
+++ b/_pages/logistics.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Logistics
+subtitle:
+permalink: /logistics/
+---
+**Welcome to Enthusiasticon 2020!!!**
+
+At EnthusiastiCon we hope to create a space that is friendly and welcoming for everyone.  
+
+In order to accomplish this we rely on you to participate and be kind to everyone else.  Below are some guidelines and logistical information we hope will help us do that.
+
+Thank you for joining - we're excited to hear about what you're enthusiastic about!
+
+-----
+
+We use Zulip as our main communication platform. It has a particular structure about it:
+* Zulip has Streams, which can be compared to Channels or Rooms in Slack IRC respectively.
+* Inside Streams, Zulip Topics hold conversations together. More details from the Zulip docs [here](https://zulip.com/why-zulip/) and [here](https://zulip.com/help/about-streams-and-topics)
+
+Some things to keep in mind about how we'll use Zulip:
+* We'll have an 'announcements' Zulip stream where we will post important logistical and organisational information
+* We'll have a stream/topic for each talk - we'll use that to ask questions, share thoughts, and applaud!
+* Let's try to keep on-topic for the event.  We have an 'off-topic' Zulip stream.  Please use that stream for anything not related to the conference.
+* We ask everyone to put their pronouns in their Zulip name, if they'd like (e.g. `Pieter (he)`).  Please respect these at all time.
+* Take care with @ing all as it will create notifications for all participants by default
+
+**We don't tolerate discriminatory language, comments, jokes, or imagery at enthusiasticon.**  Please read our [code of conduct](https://www.enthusiasticon.de/coc/)
+
+-----
+
+We have some ideals around how we'd like to interact with each other(\*).  We think these make for a more welcoming atmosphere.  It's ok to make mistakes here, the point is that we try our best to follow them.
+
+1) **If someone [doesn't know something](https://xkcd.com/1053/) and you're surprised, don't act surprised.**  We all know and don't know different things, and we want to create an atmosphere where it's ok to admit what you don't know.  eg: If someone doesn't know what Git is, and you think "wow, how can you not know that", try instead saying something like "Git's really cool, let me tell you about it"
+
+2) **Avoid correcting someone about something that's not relevant to the current discussion** Rather than being helpful, these comments tend to draw attention to the person who is making that comment. For example, if people are talking about Linux, saying "it's actually called GNU/Linux" most likely won't bring the discussion forward.
+
+3) **Please avoid [subtle expressions of discriminatory behavior](https://everydayfeminism.com/2015/10/why-microaggressions-hurt/)**, which can make others feel unwelcome, for example 'Windows is so easy that even my mom can use it'."
+
+
+\* These are inspired by the Recurse Center's  [social rules](https://www.recurse.com/social-rules)

--- a/_pages/logistics.md
+++ b/_pages/logistics.md
@@ -22,8 +22,12 @@ Some things to keep in mind about how we'll use Zulip:
 * We'll have an 'announcements' Zulip stream where we will post important logistical and organisational information
 * We'll have a stream/topic for each talk - we'll use that to ask questions, share thoughts, and applaud!
 * Let's try to keep on-topic for the event.  We have an 'off-topic' Zulip stream.  Please use that stream for anything not related to the conference.
-* We ask everyone to put their pronouns in their Zulip name, if they'd like (e.g. `Pieter (he)`).  Please respect these at all time.
+* We ask everyone to put their pronouns in their Zulip name (e.g. Rubberduck (they) or Rubberduck (she)). Please respect these at all time. If you don't use pronouns, you're also welcome to make that explicit: Rubberduck (no pronouns)
 * Take care with @ing all as it will create notifications for all participants by default
+
+To reach us, you can use @*organizers* (use the dropdown menu)
+
+-----
 
 **We don't tolerate discriminatory language, comments, jokes, or imagery at enthusiasticon.**  Please read our [code of conduct](https://www.enthusiasticon.de/coc/)
 

--- a/_pages/logistics.md
+++ b/_pages/logistics.md
@@ -35,7 +35,7 @@ We have some ideals around how we'd like to interact with each other(\*).  We th
 
 2) **Avoid correcting someone about something that's not relevant to the current discussion**.  Rather than being helpful, these comments tend to draw attention to the person who is making that comment. For example, if people are talking about Linux, saying "it's actually called GNU/Linux" most likely won't bring the discussion forward.
 
-3) **Please avoid [subtle discriminatory language](https://everydayfeminism.com/2015/10/why-microaggressions-hurt/)**, which can make others feel unwelcome.  For example 'Windows is so easy that even my mom can use it'."
+3) **Please avoid [subtle discriminatory language](https://everydayfeminism.com/wp-content/uploads/2015/10/microaggressions.jpg)**, which can make others feel unwelcome.  For example 'Windows is so easy that even my mom can use it'."
 
 
 \* These are inspired by the Recurse Center's  [social rules](https://www.recurse.com/social-rules)

--- a/_pages/logistics.md
+++ b/_pages/logistics.md
@@ -31,11 +31,11 @@ Some things to keep in mind about how we'll use Zulip:
 
 We have some ideals around how we'd like to interact with each other(\*).  We think these make for a more welcoming atmosphere.  It's ok to make mistakes here, the point is that we try our best to follow them.
 
-1) **If someone [doesn't know something](https://xkcd.com/1053/) and you're surprised, don't act surprised.**  We all know and don't know different things, and we want to create an atmosphere where it's ok to admit what you don't know.  eg: If someone doesn't know what Git is, and you think "wow, how can you not know that", try instead saying something like "Git's really cool, let me tell you about it"
+1) **If someone [doesn't know something](https://xkcd.com/1053/) and you're surprised, don't act surprised.**  We all know and don't know different things, and we want to create an atmosphere where it's ok to admit what you don't know.  eg: If someone doesn't know what Git is, and you think "wow, how can you not know that", try instead saying something like "Git's really cool! let me tell you about it!"
 
-2) **Avoid correcting someone about something that's not relevant to the current discussion** Rather than being helpful, these comments tend to draw attention to the person who is making that comment. For example, if people are talking about Linux, saying "it's actually called GNU/Linux" most likely won't bring the discussion forward.
+2) **Avoid correcting someone about something that's not relevant to the current discussion**.  Rather than being helpful, these comments tend to draw attention to the person who is making that comment. For example, if people are talking about Linux, saying "it's actually called GNU/Linux" most likely won't bring the discussion forward.
 
-3) **Please avoid [subtle expressions of discriminatory behavior](https://everydayfeminism.com/2015/10/why-microaggressions-hurt/)**, which can make others feel unwelcome, for example 'Windows is so easy that even my mom can use it'."
+3) **Please avoid [subtle discriminatory language](https://everydayfeminism.com/2015/10/why-microaggressions-hurt/)**, which can make others feel unwelcome.  For example 'Windows is so easy that even my mom can use it'."
 
 
 \* These are inspired by the Recurse Center's  [social rules](https://www.recurse.com/social-rules)


### PR DESCRIPTION
Add logistics page (without adding it to the menu)

Changes to the actual text:
- less repetitive at the start
- make it clearer the social rules parts are ideals rather than rules really ( I thought the way it was could be a bit intimidating for non RC people)
- make it clear you don't have to put pronouns if you don't want (because some people don't use pronouns)

-----
![l_1](https://user-images.githubusercontent.com/22727289/83351421-9c5d9c80-a33b-11ea-8f56-f935ca57a0f1.png)
![l_2](https://user-images.githubusercontent.com/22727289/83351422-9cf63300-a33b-11ea-85b3-f3c58a3ae906.png)
![l_3](https://user-images.githubusercontent.com/22727289/83351424-9ebff680-a33b-11ea-905a-5476027b4abc.png)




