### PR TITLE
Add stream page 

### DIFF
--- a/_pages/stream.md
+++ b/_pages/stream.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Welcome to Enthusiasticon 2020!
+permalink: /stream/
+---
+# Welcome to Enthusiasticon 2020!
+
+{::nomarkdown}
+<iframe id="captionsFrame"
+    src="//www.streamtext.net/player/?event=IHaveADream&chat=false&header=false&footer=false&title=false&controls=true"
+    width="100%"> </iframe>
+{:/}

--- a/_pages/stream.md
+++ b/_pages/stream.md
@@ -7,6 +7,8 @@ permalink: /stream/
 
 {::nomarkdown}
 <iframe id="captionsFrame"
-    src="//www.streamtext.net/player/?event=IHaveADream&chat=false&header=false&footer=false&title=false&controls=true"
+    src="//www.streamtext.net/player?event=enthusiasticon&chat=false&header=false&footer=false&title=false&controls=true"
     width="100%"> </iframe>
 {:/}
+
+You can also view captions directly [here](https://www.streamtext.net/player?event=enthusiasticon)


### PR DESCRIPTION
Includes:
- So far this page just has a sample captions url embedded

Note:
- There are a bunch of other options for the captions, I didn't try them all.  It might be more readable to have bigger text & line spacing, but that might override user settings.  We could talk about this when we do the captions tech test
- The icon at the bottom right is the connection status, we can remove it but might be useful

----
![captions](https://user-images.githubusercontent.com/22727289/83395828-e190d580-a3f2-11ea-858e-92c020731ebe.png)
![captions_connected](https://user-images.githubusercontent.com/22727289/83397244-31709c00-a3f5-11ea-88e8-9f94421917bc.png)
